### PR TITLE
make word wrapping consistent at 80 characters

### DIFF
--- a/exercises/call-me-maybe/instruction.md
+++ b/exercises/call-me-maybe/instruction.md
@@ -1,21 +1,22 @@
 # Call me maybe
 
-Write a test for a function `repeatCallback(n, cb)`, that calls the callback `cb`
-exactly `n` times.
+Write a test for a function `repeatCallback(n, cb)`, that calls the callback 
+`cb` exactly `n` times.
 
 As before the functions location will be provided through `process.argv[2]`.
 
 ## Hints
 
-Sometimes we are not simply checking return values of functions. A lot in JavaScript
-and node happens through callbacks and events. For this we often want to know:
-Was that callback called or not?
+Sometimes we are not simply checking return values of functions. A lot in 
+JavaScript and node happens through callbacks and events. For this we often want
+to know: Was that callback called or not?
 
 The event-driven nature of JavaScript is also the reason why we had to call the 
 `t.end()` function in the last level. The test has to know whether we are done.
 
 However there is maybe a better way to do this with callbacks using `t.plan(n)`.
-When we call this in the beginning we can tell `tape` how many assertions we are doing.
+When we call this in the beginning we can tell `tape` how many assertions we are
+doing.
 
 ```js
   var test = require('tape')
@@ -27,7 +28,7 @@ When we call this in the beginning we can tell `tape` how many assertions we are
   })
 ```
 
-In this example we only have one callback, which will simply pass the test when it 
-is called. So we could have used `t.end()` within the callback instead. However you
-might see, that if we had multiple callbacks in our tests the `t.plan(n)` would come 
-in handy.
+In this example we only have one callback, which will simply pass the test when
+it is called. So we could have used `t.end()` within the callback instead.
+However you might see, that if we had multiple callbacks in our tests the 
+`t.plan(n)` would come in handy.

--- a/exercises/log-it-out/instruction.md
+++ b/exercises/log-it-out/instruction.md
@@ -1,15 +1,16 @@
 # Log it out
 
-Developing apps and modules is fun. However often you might be concerned whether things
-work or when you add new features you want to be sure you did not break anything. 
-Therefore developers invented tests for their well-being. They allow you to automatically,
-well, test your application or module.
+Developing apps and modules is fun. However often you might be concerned whether
+things work or when you add new features you want to be sure you did not break
+anything. Therefore developers invented tests for their well-being. They allow 
+you to automatically, well, test your application or module.
 
-Let's assume you wrote a function called `emotify`, which takes a String and adds
-a space and a `:)` to it. How would you check that your function is working?
+Let's assume you wrote a function called `emotify`, which takes a String and
+adds a space and a `:)` to it. How would you check that your function is
+working?
 
-Maybe your first idea was calling the function with a value and `console.log` the 
-result and then check its output in the console.
+Maybe your first idea was calling the function with a value and `console.log`
+the result and then check its output in the console.
 
 ```js
   var emotify = require('./emotify.js')
@@ -17,4 +18,5 @@ result and then check its output in the console.
 ```
 
 Try this yourself. We are going to provide the location for the awesome
-`emotify` module in `process.argv[2]` and the String for the test in `process.argv[3]`.
+`emotify` module in `process.argv[2]` and the String for the test in
+`process.argv[3]`.

--- a/exercises/tape-it-together/instruction.md
+++ b/exercises/tape-it-together/instruction.md
@@ -7,7 +7,7 @@ Write tests that output `TAP`, that tests the following properties of a function
   Example: `fancify('Hello')` returns `~*~Hello~*~`
 2 It takes an optional second argument that converts the string into ALLCAPS
   Example: `fancify('Hello', true)` returns `~*~HELLO~*~`
-3 It takes a third optional argument, that determines the character in the middle
+3 It takes a third optional argument that determines the character in the middle
   Example: `fancify('Hello', false, '!')` returns `~!~Hello~!~`
 
 ## Hints
@@ -15,12 +15,13 @@ Write tests that output `TAP`, that tests the following properties of a function
 Testing with `assert` still has some downsides. Even though we don't have to
 check all the values ourself like in the first level, but now we only get not
 very readable errors when something is wrong. Otherwise our tests just don't do
-nothing. Maybe we still would like to see some information that everything is ok.
+nothing. Maybe we still would like to see some information that everything is
+ok.
 
 
 There is a standard for outputting data from tests called `TAP`, the 
-`Test Anything Protocol`. It is nicely readable for humans as well as for our robotic
-friends.
+`Test Anything Protocol`. It is nicely readable for humans as well as for our
+robotic friends.
 
 One module for testing that outputs `TAP` is `tape` (another one is `tap`, duh).
 It takes a description of what your are testing and a callback function, with a

--- a/exercises/tell-me-what-is-wrong/instruction.md
+++ b/exercises/tell-me-what-is-wrong/instruction.md
@@ -3,29 +3,32 @@
 Write a passing assertion for the function `isCoolNumber`, that will assure that
 it returns `true` when passing `42` in it.
 
-The path of the module exporting the function will be provided through `process.argv[2]`.
+The path of the module exporting the function will be provided through
+`process.argv[2]`.
 
 -----
 
 ## Hints
 
-Well this was probably nothing new for you. But wait don't leave, we are going to 
-learn about some better ways to do this. 
+Well this was probably nothing new for you. But wait don't leave, we are going
+to learn about some better ways to do this. 
 
 If you are wondering, what's wrong about `console.log`, then think about this: 
-If your functions are going to be more complex
-it is going to be harder and harder to actually read the output. You have to know 
-what output is expected for every input and for different functions.
+If your functions are going to be more complex it is going to be harder and
+harder to actually read the output. You have to know what output is expected for
+every input and for different functions.
 
-So it would be better if our tests only told us about weather something works or not. 
-Surely we could probably test each output with `!==` and warn if something is wrong like this.
+So it would be better if our tests only told us about weather something works or
+not. Surely we could probably test each output with `!==` and warn if something
+is wrong like this.
 
 ```js
   if(add(2,1) !== 3) throw new Error('add(2,1) should be 3')
 ```
 
-Now we get an error every time something is wrong, with the message what's not working.
-However in node there is a nice build-in module for this called `assert`.
+Now we get an error every time something is wrong, with the message what's not
+working. However in node there is a nice build-in module for this called
+`assert`.
 
 ```js
   var assert = require('assert')

--- a/exercises/to-err-is-human/instruction.md
+++ b/exercises/to-err-is-human/instruction.md
@@ -1,8 +1,8 @@
 # To err is human
 
-A function `feedCat` takes any kind of food as a String argument and returns `'yum'`
-for everything you feed them. However if you try to feed the cat `'chocolate'`, the
-function will throw an error.
+A function `feedCat` takes any kind of food as a String argument and returns 
+`'yum'` for everything you feed them. However if you try to feed the cat 
+`'chocolate'`, the function will throw an error.
 
 Write a tests for this behavior, to be sure no kittens are harmed.
 
@@ -16,9 +16,9 @@ Chocolate is awesome and so are cats. However they do not make a wonderful
 combination. The Caffeine and Theobromine in the chocolate can harm cats as well
 as dogs. 
 
-Feeding chocolate to cats would therefore considered an error. One way in javascript
-to deal with errors is to `throw` them (even though in Node this is probably no the
-best way). 
+Feeding chocolate to cats would therefore considered an error. One way in
+JavaScript to deal with errors is to `throw` them (even though in Node this is
+probably not the best way). 
 
 If we want to deal with these errors, we can use `try` and `catch` like this:
 
@@ -31,11 +31,11 @@ catch(err) {
 }
 ```
 
-When we test things, we often say that we want to make sure that there are no errors.
-Well, that is not entirely true. We certainly want not to have errors in our code.
-However if someone else tries to something weird with our functions, it still might
-be good to see an errors. So good that we might want to test this behavior, e.g. 
-to make sure there is no chocolate fed to cats.
+When we test things, we often say that we want to make sure that there are no
+errors. Well, that is not entirely true. We certainly want not to have errors in
+our code. However if someone else tries to something weird with our functions,
+it still might be good to see an errors. So good that we might want to test this
+behavior, e.g. to make sure there is no chocolate fed to cats.
 
 So maybe we know that a dachshund does not like to be petted. Well we could test 
 this behavior like this:
@@ -46,11 +46,11 @@ t.throws(function () {
 })
 ```
 
-Now the tests expects an error and throws an error if there is no error.
-Mind boggling, right?
+Now the tests expects an error and throws an error if there is no error. Mind
+boggling, right?
 
-By the way, if you are familiar with functional javascript, you might already know, 
-that you could also write it in one line:
+By the way, if you are familiar with functional javascript, you might already
+know, that you could also write it in one line:
 ```js
 t.throws(petDog.bind(null, 'dachhund'))
 ```


### PR DESCRIPTION
Word wrapping seems somewhat inconsistent. On a standard 80-character wide window, we get this:

![screen shot 2015-04-20 at 10 19 19 pm](https://cloud.githubusercontent.com/assets/718899/7246175/d57afa8e-e7ad-11e4-9226-a5ba63f44adb.png)

With the changes in this PR, it looks like this instead:

![screen shot 2015-04-20 at 10 36 15 pm](https://cloud.githubusercontent.com/assets/718899/7246180/e0d2b23c-e7ad-11e4-9f2b-4ae955369440.png)
