### PR TITLE
Update index.js

### DIFF
--- a/exercises/utils/index.js
+++ b/exercises/utils/index.js
@@ -38,7 +38,7 @@ exports.execRun = function (args, dirname) {
   out += [
     'Create your own module (`metatest.js`) to test your test.',
     'Then run your code like this:',
-    '`node ' + args[0] + ' metatest.js`',
+    '`node ' + args[0] + ' ./metatest.js`',
     'The `metatest.js` file could look like this to pass your',
     'tests:'
   ].join('\n')


### PR DESCRIPTION
Change the way files are addressed in `run` command output - add relativity.
With current instruction if you create a file in the same folder you will get
```
node tape_it_together.js metatest.js                                                                                                   [node v0.10.31]

module.js:340
    throw err;
          ^
Error: Cannot find module 'metatest.js'
```
and `node tape_it_together.js ./metatest.js` does what it should (it looks like).