### PR TITLE
increase clarity of the requirement for the 'call me maybe' exercise

### DIFF
--- a/exercises/call-me-maybe/instruction.md
+++ b/exercises/call-me-maybe/instruction.md
@@ -1,7 +1,7 @@
 # Call me maybe
 
 Write a test for a function `repeatCallback(n, cb)`, that calls the callback 
-`cb` exactly `n` times.
+`cb` exactly `n` times. `n` can be any number you want in your test code.
 
 As before the functions location will be provided through `process.argv[2]`.
 


### PR DESCRIPTION
Hello,

Thank you for your awesome exercises, this made writing unit tests fun for me!

I had an issue interpreting the requirements from 'Call me maybe' exercise.
I tried with:

```
t.plan(n);        
repeatCallback(n, function () {
    t.pass('callback called')
});
```

but the tests wouldn't pass.

In my head the `n` I thought it was send from the module that tests my test code. It should be clear from the requirement that `n` can be any number. 
