### PR TITLE
Fix workshopper execution on Linux/Ubuntu

### DIFF
--- a/test-anything.js
+++ b/test-anything.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-deprecation
+#!/usr/bin/env node
 
 var adventure = require('adventure')
 


### PR DESCRIPTION
For some unknown reasons, Linux seems not to allow multiple arguments in shebang, so while running `test-anything` command after install will cause the following error **on Linux/Ubuntu** : 

`/usr/bin/env: «node --no-deprecation»: Aucun fichier ou dossier de ce type` ✖

The only fix I could find was to remove the second parameter `--no-deprecation` in the shebang.

`#!/usr/bin/env node` ✔